### PR TITLE
Allow to dispose an AgoraRtcEngine object without created device managers

### DIFF
--- a/agorartc/agorartc/AgoraRtcEngine.cs
+++ b/agorartc/agorartc/AgoraRtcEngine.cs
@@ -440,9 +440,9 @@ namespace agorartc
                     value.Dispose();
                 }
 
-                _videoDeviceManager.Dispose();
-                _audioRecordingDeviceManager.Dispose();
-                _audioPlaybackDeviceManager.Dispose();
+                _videoDeviceManager?.Dispose();
+                _audioRecordingDeviceManager?.Dispose();
+                _audioPlaybackDeviceManager?.Dispose();
             }
 
             Release();


### PR DESCRIPTION
If I create an `AgoraRtcEngine` object but don't create any device manager (`CreateVideoDeviceManager()`, `CreateAudioRecordingDeviceManager()`, `CreateAudioPlaybackDeviceManager()`) and then try to dispose it, a `NullReferenceException` is thown, because the `AgoraRtcEngine.Dispose(bool disposing)` method expects all device manager properties to exist.

### Example:
```csharp
var agora = AgoraRtcEngine.CreateRtcEngine();

// Don't call any of these:
// agora.CreateVideoDeviceManager();
// agora.CreateAudioRecordingDeviceManager();
// agora.CreateAudioPlaybackDeviceManager();

// ...

agora.Dispose();
// throws NullReferenceException
```

### Fix:

A simple null check fixes this issue.

#### Before:
```csharp
private void Dispose(bool disposing)
{
    // ...
    _videoDeviceManager.Dispose();
    _audioRecordingDeviceManager.Dispose();
    _audioPlaybackDeviceManager.Dispose();
    // ...
}
```

#### After:
```csharp
private void Dispose(bool disposing)
{
    // ...
    _videoDeviceManager?.Dispose();
    _audioRecordingDeviceManager?.Dispose();
    _audioPlaybackDeviceManager?.Dispose();
    // ...
}
```